### PR TITLE
🔊 Log the stack trace upon error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Breaking change:
 
 - Drop support for Node.js 16.
 
+Features:
+
+- Log a debug message with the stack trace upon error.
+
 Chore:
 
 - Upgrade dependencies.

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -168,11 +168,15 @@ describe('command', () => {
         logger,
       });
       jest.spyOn(logger, 'error');
+      jest.spyOn(logger, 'debug');
 
       const actualExitCode = await runCli(['myFunction', '💥'], context);
 
       expect(actualExitCode).toEqual(1);
       expect(logger.error).toHaveBeenCalledExactlyOnceWith('❌ 🚨');
+      expect(logger.debug).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining('MyFunctionImpl._call'),
+      );
     });
 
     it('should show help and return 1 when no argument is passed', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,6 +73,7 @@ export async function runCli(
 
     const message = error.message ?? error;
     logger.error(`❌ ${message}`);
+    logger.debug(error.stack);
 
     if (!isInitializationSuccessful) {
       showHelpForCommand(program, logger);


### PR DESCRIPTION
When an error is thrown by a workspace function, it was already logged at the `error` level. This adds another `debug` level message that outputs the stack trace.

### Commits

- **🔊 Log a debug message with the stack trace upon error**
- **📝 Update changelog**