### PR TITLE
🔖 Prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.5.0 (2024-05-17)
+
 Breaking change:
 
 - Drop support for Node.js 16.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/cli",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/cli",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.13.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/cli",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Exposes the command line interface for the Causa (`cs`) command.",
   "repository": "github:causa-io/cli",
   "license": "ISC",


### PR DESCRIPTION
Breaking change:

- Drop support for Node.js 16.

Features:

- Log a debug message with the stack trace upon error.

Chore:

- Upgrade dependencies.

### Commits

- **🔖 Set version to 0.5.0**
- **📝 Update changelog**