### PR TITLE
✨ Pass workspace function arguments to the CLI's `outputFn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Pass function arguments to the `outputFn` of `@CliCommand`s.
+
 ## v0.5.0 (2024-05-17)
 
 Breaking change:

--- a/src/context/context.spec.ts
+++ b/src/context/context.spec.ts
@@ -62,14 +62,21 @@ describe('CliContext', () => {
 
     it('should run the function and call the output function', async () => {
       let output!: string;
+      let args!: any;
 
       await context.runWorkspaceFunctionAsAction(
         MyFunction,
         { arg: '🎉' },
-        { outputFn: (o) => (output = o) },
+        {
+          outputFn: (o, a) => {
+            output = o;
+            args = a;
+          },
+        },
       );
 
       expect(output).toEqual('🎉');
+      expect(args).toEqual({ arg: '🎉' });
       expect(process.exitCode).toEqual(initialExitCode);
     });
 

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -55,7 +55,7 @@ export class CliContext {
     const output = await this.workspace.call(definition, args);
 
     if (options.outputFn) {
-      await options.outputFn(output);
+      await options.outputFn(output, args);
     }
   }
 }

--- a/src/function-decorators/command.decorator.ts
+++ b/src/function-decorators/command.decorator.ts
@@ -1,5 +1,6 @@
 import { WorkspaceFunction } from '@causa/workspace';
 import type {
+  ImplementableFunctionArguments,
   ImplementableFunctionDefinitionConstructor,
   ImplementableFunctionReturnType,
 } from '@causa/workspace/function-registry';
@@ -24,6 +25,7 @@ export type ParentCliCommandDefinition = Pick<
  */
 export type CliCommandOutputFunction<D extends WorkspaceFunction<any>> = (
   output: Awaited<ImplementableFunctionReturnType<D>>,
+  args: ImplementableFunctionArguments<D>,
 ) => Promise<any> | any;
 
 /**


### PR DESCRIPTION
This allows a workspace function decorated with `@CliCommand` to access the function's arguments in `outputFn`. This allows the output function to adapt its behaviour based on the function's arguments, not just its output. An example use case is to let the caller choose the output format (text or JSON). The output of the function itself doesn't change, but the way it is written to the standard output does.

### Commits

- **✨ Pass function arguments to the CLI output function**
- **📝 Update changelog**