### PR TITLE
🔖 Prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.6.0 (2024-10-07)
+
 Features:
 
 - Pass function arguments to the `outputFn` of `@CliCommand`s.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/cli",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.16.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Exposes the command line interface for the Causa (`cs`) command.",
   "repository": "github:causa-io/cli",
   "license": "ISC",


### PR DESCRIPTION
Features:

- Pass function arguments to the `outputFn` of `@CliCommand`s.

### Commits

- **🔖 Set version to 0.6.0**
- **📝 Update changelog**