### PR TITLE
🔖 Prepare v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.6.2 (2025-08-05)
+
 Breaking changes:
 
 - Upgrade the minimum Node.js version to `20`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/cli",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.17.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Exposes the command line interface for the Causa (`cs`) command.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Upgrade the minimum Node.js version to `20`.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- [x] 📝 Documentation has been updated.