### PR TITLE
🔖 Prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.7.0 (2026-04-13)
+
 Breaking changes:
 
 - Remove support for Node.js 20.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/cli",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/cli",
-      "version": "0.6.6",
+      "version": "0.7.0",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.23.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/cli",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "description": "Exposes the command line interface for the Causa (`cs`) command.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Remove support for Node.js 20.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~