### PR TITLE
⬆️ Upgrade Causa modules to 1.0.0

### DIFF
--- a/causa.yaml
+++ b/causa.yaml
@@ -11,8 +11,8 @@ project:
 
 causa:
   modules:
-    '@causa/workspace-core': '>= 0.29.0'
-    '@causa/workspace-typescript': '>= 0.19.2'
+    '@causa/workspace-core': ^1.0.0
+    '@causa/workspace-typescript': ^1.0.0
 
 javascript:
   dependencies:


### PR DESCRIPTION
### 📝 Description of the PR

Upgrades the Causa workspace modules to their first stable release, bumping the version constraints for `@causa/workspace-core` and `@causa/workspace-typescript` to `^1.0.0`.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~